### PR TITLE
added option cell_type_column

### DIFF
--- a/R/calc_csi_module_activity.R
+++ b/R/calc_csi_module_activity.R
@@ -8,14 +8,13 @@
 #' @examples
 #'
 
-calc_csi_module_activity <- function(clusters_df,
-                                     regulonAUC,
-                                     metadata){
+calc_csi_module_activity <- function(clusters_df,regulonAUC,metadata,cell_type_column){
 
   require(tidyverse)
   require(pheatmap)
   require(viridis)
-
+  
+  metadata$cell_type <- metadata[ , cell_type_column ]
   cell_types<- unique(metadata$cell_type)
   regulons <- unique(clusters_df$regulon)
 
@@ -24,8 +23,8 @@ calc_csi_module_activity <- function(clusters_df,
 
   csi_activity_matrix_list <- list()
   csi_cluster_activity <- data.frame("csi_cluster" = c(),
-                                    "mean_activity" = c(),
-                                    "cell_type" = c())
+                                     "mean_activity" = c(),
+                                     "cell_type" = c())
 
   cell_type_counter <- 0
   regulon_counter <-


### PR DESCRIPTION
To avoid using by default the cell_type columns from the metadata, there is now a cell_type_column option. Internally, the cell_type column is created.